### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
           pytest --cov=pymodaq_utils --ignore-glob='*legacy*' -n 1
           mv .coverage coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: generate badge (success)
         if: ${{ success() }}
-        uses: emibcn/badge-action@v2.0.2
+        uses: emibcn/badge-action@v2.0.3
         with:
           label: ''
           status: 'passing'
@@ -88,7 +88,7 @@ jobs:
           path: '${{ steps.extract_branch.outputs.branch }}/tests_${{runner.os}}_${{matrix.python-version}}.svg'
       - name: generate badge (fail)
         if: ${{ failure() }}
-        uses: emibcn/badge-action@v2.0.2
+        uses: emibcn/badge-action@v2.0.3
         with:
           label: ''
           status: 'failing'
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload badge artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name:  tests_${{runner.os}}_${{matrix.python-version}}
           path: '${{ steps.extract_branch.outputs.branch }}/tests_${{runner.os}}_${{matrix.python-version}}.svg'
@@ -112,12 +112,12 @@ jobs:
     needs: tests # Ensure this job runs after all matrix jobs complete
     steps:
        # switch to badges branches to commit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
 
       - name: Reorganize badges
         run: |
@@ -136,7 +136,7 @@ jobs:
           git commit  --allow-empty -m "Add/Update badge"
 
       - name: Push badges
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         if: ${{ success() }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           path: ./coverage-reports
 
@@ -171,7 +171,7 @@ jobs:
           coverage xml -i
 
       - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.0.7
+        uses: codecov/codecov-action@v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.5.0](https://github.com/actions/upload-artifact/releases/tag/v4.5.0)** on 2024-12-17T22:02:43Z
* **[emibcn/badge-action](https://github.com/emibcn/badge-action)** published a new release **[v2.0.3](https://github.com/emibcn/badge-action/releases/tag/v2.0.3)** on 2024-02-07T08:40:09Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v0.8.0](https://github.com/ad-m/github-push-action/releases/tag/v0.8.0)** on 2023-10-10T04:56:58Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.1.2](https://github.com/codecov/codecov-action/releases/tag/v5.1.2)** on 2024-12-18T18:45:28Z
