### PR TITLE
Changed fallback version to 0.0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ Tracker = "https://github.com/PyMoDAQ/pymodaq_utils/issues"
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.0.7"
+fallback-version = "0.0.9"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
Pymodaq_data requirements is pymodaq_utils > 0.0.8 and fallback version was 0.0.7
We need the fallback version if we use pip to install from git to determine the version and match the pymodaq_data requirements.