### PR TITLE
Added a section to provide optional development dependancies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,16 @@ dependencies = [
     "toml",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "hatch", 
+    "flake8",
+    "h5py",
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+]
+
 [project.scripts]
 
 [project.urls]


### PR DESCRIPTION
The `pyproject.toml` file was modified to include the development dependencies so they can easily be installed with `pip install -e ".[dev]"`