### PR TITLE
Exclude resource folder from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,8 @@ fallback-version = "0.0.9"
 include = [
     "/src",
 ]
+
+[tool.coverage.run]
+omit = [
+    "*/resources/*"
+]


### PR DESCRIPTION
It excludes `resource` folder from coverage