### PR TITLE
Script & weekly github action to check plugins compatibility

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,53 @@
+name: Compatibility verification between PyMoDAQ and plugins
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs at midnight UTC every Sunday
+  workflow_dispatch:
+
+jobs:
+  check-compatibility:
+    strategy:
+      fail-fast: false
+      matrix:
+        pymodaq-version: ["4.4.x", "5.0.x_dev"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Checkout pymodaq_utils
+        uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-cursor0 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1
+          export QT_DEBUG_PLUGINS=1
+
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install hatch pyqt5
+          pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}
+
+      - name: Run script
+        run: |
+          source venv/bin/activate
+          python compatibility/checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
+
+      - name: Upload reports if failed
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-reports-${{ matrix.pymodaq-version }}
+          path: reports
+
+      - name: Check version
+        if: always()
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          source venv/bin/activate
+          pip list

--- a/compatibility/checker.py
+++ b/compatibility/checker.py
@@ -13,7 +13,7 @@ from pymodaq_plugin_manager.validate import get_plugins, get_pypi_pymodaq, get_p
 
 # Could be better but global variables works
 REPORT_FOLDER = Path("./reports/")
-PYMODAQ = "pymodaq"
+PYMODAQ = ""
 
 def _detect_encoding(filename):
     '''
@@ -131,7 +131,8 @@ def main():
     code = 0
     REPORT_FOLDER.mkdir(parents=True, exist_ok=True)
 
-    # If there's a parameter, is should be PyMoDAQ source of installation 
+    # If there's a parameter, is should be PyMoDAQ source of installation
+    # otherwise, it will be the installed version 
     if(len(sys.argv) >  1):
         PYMODAQ = sys.argv[1]
     

--- a/compatibility/checker.py
+++ b/compatibility/checker.py
@@ -1,0 +1,151 @@
+import chardet
+import logging
+import ast
+import sys
+from pathlib import Path
+import subprocess
+import importlib
+
+
+from pymodaq_plugin_manager.utils import get_pymodaq_version
+from pymodaq_plugin_manager.validate import get_plugins, get_pypi_pymodaq, get_package_metadata, get_pypi_plugins
+
+
+# Could be better but global variables works
+REPORT_FOLDER = Path("./reports/")
+PYMODAQ = "pymodaq"
+
+def _detect_encoding(filename):
+    '''
+       Detect encoding of a file 
+
+    Parameters
+    ----------
+    filename: str
+        the file for which the encoding is to be detected
+    Returns
+    -------
+    str:
+        The encoding
+    '''
+    with open(filename, "rb") as f:
+        raw = f.read()
+        return chardet.detect(raw)['encoding']
+
+class PyMoDAQPlugin:
+    '''
+        A simple class to represent a PyMoDAQ plugin, from a `pip install`
+        point of view
+    '''
+    def __init__(self, name, version):
+        self._name = name
+        self._version = version
+        self._install_result = None
+
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def version(self):
+        return self._version
+    
+    def _get_location(self):
+        return importlib.util.find_spec(self._name).submodule_search_locations[0]
+
+    def install(self) -> bool:
+        '''
+           Try to install this plugin using pip
+
+        Returns
+        -------
+        bool:
+            True if the plugin could be installed or is already installed, False otherwise    
+        '''
+        command = [sys.executable, '-m', 'pip', 'install', PYMODAQ, f'{self._name}=={self._version}']
+        self._install_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return self._install_result.returncode == 0
+
+    def _save_report(self, name, stream):
+        with open(REPORT_FOLDER / name, 'w') as f:
+            f.write(stream)
+
+    def save_install_report(self):
+        self._save_report(f'install_report_{self._name}_{self._version}.txt', self._install_result.stdout)
+    
+    def save_import_report(self):
+        self._save_report(f'import_report_{self._name}_{self._version}.txt', '\n'.join(self._failed_imports + [''])) 
+
+    def all_imports_valid(self) -> bool:
+        '''
+            Check if this plugin imports are all valid
+
+        Returns
+        -------
+        bool:
+            True if all imports are valid (no import failed), False otherwise    
+        '''
+        self._failed_imports = []
+        install_path = self._get_location()
+
+        for filename in Path(install_path).glob('**/*.py'):
+            with open(filename, 'r', encoding=_detect_encoding(filename)) as f:
+                tree = ast.parse(f.read(), filename=filename)
+                for node in tree.body:
+                    try:
+                        if (isinstance(node, ast.ImportFrom) and 'pymodaq' in node.module) \
+                        or (isinstance(node, ast.Import) and any('pymodaq' in name.name for name in node.names)):
+                            for name in node.names:
+                                try:
+                                    if isinstance(node, ast.ImportFrom):
+                                        import_code = f'from {node.module} import {name.name}'
+                                        getattr(importlib.import_module(node.module), name.name)                            
+                                    elif isinstance(node, ast.Import):
+                                        import_code = f'import {name.name}'
+                                        if name.asname:
+                                            import_code += f' as {name.asname}'
+                                        importlib.import_module(node.module)
+                                
+                                except (ImportError, ModuleNotFoundError):
+                                    self._failed_imports.append(f'"{import_code}" in {filename} ({node.lineno})') 
+                                except Exception as e:
+                                    print(f'Unknown: {e}')
+                    except TypeError as te:
+                        pass
+        
+        return len(self._failed_imports) == 0
+
+
+
+def main():
+    '''
+        The script use `get_pypi_plugins` function to get a list of all PyMoDAQ plugins.
+        Then it tries to install each plugin. If it fails it write a report (in `REPORT_FOLDER`)
+        Otherwise, it tries to execute all its import clauses containing "pymodaq". If at least 
+        one import fail, a report is made (with relevant information).
+
+        Finally, if something failed, the script signal it by returning with an exit code of 1.
+    '''
+    global PYMODAQ
+    
+    code = 0
+    REPORT_FOLDER.mkdir(parents=True, exist_ok=True)
+
+    # If there's a parameter, is should be PyMoDAQ source of installation 
+    if(len(sys.argv) >  1):
+        PYMODAQ = sys.argv[1]
+    
+    plugin_list = get_pypi_plugins()
+    
+    for p in plugin_list:
+        plugin = PyMoDAQPlugin(p['plugin-name'], p['version'])
+        if plugin.install():
+            if not plugin.all_imports_valid():
+                plugin.save_import_report()
+                code = 1
+        else:
+            plugin.save_install_report()
+            code = 1
+    sys.exit(code)
+if __name__ == '__main__':
+    main()

--- a/compatibility/checker.py
+++ b/compatibility/checker.py
@@ -5,15 +5,11 @@ import sys
 from pathlib import Path
 import subprocess
 import importlib
+import argparse
 
 
 from pymodaq_plugin_manager.utils import get_pymodaq_version
 from pymodaq_plugin_manager.validate import get_plugins, get_pypi_pymodaq, get_package_metadata, get_pypi_plugins
-
-
-# Could be better but global variables works
-REPORT_FOLDER = Path("./reports/")
-PYMODAQ = ""
 
 def _detect_encoding(filename):
     '''
@@ -62,12 +58,15 @@ class PyMoDAQPlugin:
         bool:
             True if the plugin could be installed or is already installed, False otherwise    
         '''
-        command = [sys.executable, '-m', 'pip', 'install', PYMODAQ, f'{self._name}=={self._version}']
+        command = [sys.executable, '-m', 'pip', 'install', f'{self._name}=={self._version}']
+        if args.pymodaq:
+            command.append(args.pymodaq)
+            
         self._install_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         return self._install_result.returncode == 0
 
     def _save_report(self, name, stream):
-        with open(REPORT_FOLDER / name, 'w') as f:
+        with open(args.reports_path / name, 'w') as f:
             f.write(stream)
 
     def save_install_report(self):
@@ -115,26 +114,29 @@ class PyMoDAQPlugin:
         
         return len(self._failed_imports) == 0
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect incompatibilities between a PyMoDAQ version and the released plugins")
+    parser.add_argument("-r", type=Path, default=Path("reports/"), dest="reports_path", help="Path to the reports folder (default: reports/)")
+    parser.add_argument(nargs="?", type=str, default="", dest="pymodaq", help="Installation source of the PyMoDAQ package (default: empty string)")
 
+    return parser.parse_args()
 
 def main():
     '''
         The script use `get_pypi_plugins` function to get a list of all PyMoDAQ plugins.
-        Then it tries to install each plugin. If it fails it write a report (in `REPORT_FOLDER`)
+        Then it tries to install each plugin. If it fails it write a report (in `args.reports_path`)
         Otherwise, it tries to execute all its import clauses containing "pymodaq". If at least 
         one import fail, a report is made (with relevant information).
 
         Finally, if something failed, the script signal it by returning with an exit code of 1.
     '''
-    global PYMODAQ
+    global args
+
+    args = parse_args()
     
     code = 0
-    REPORT_FOLDER.mkdir(parents=True, exist_ok=True)
+    args.reports_path.mkdir(parents=True, exist_ok=True)
 
-    # If there's a parameter, is should be PyMoDAQ source of installation
-    # otherwise, it will be the installed version 
-    if(len(sys.argv) >  1):
-        PYMODAQ = sys.argv[1]
     
     plugin_list = get_pypi_plugins()
     


### PR DESCRIPTION
This PR provides a script (`compatibility/checker.py`) to check for the compatibility of `import` statements between a plugin and a PyMoDAQ version.

It is called like that:

```bash
python compatibility/checker.py [pymodaq_source_of_installation]
```
`pymodaq_source_of_installation` being an optional argument to tell the script which version to pymodaq to install. It is a git link, a "pymodaq==<version>" string, etc. In the case where it's empty, the script with either use the installed version or install the last version available on pip if no version are installed. 

Reports will be generated in the `reports` folder.



There is also a weekly github action to run the script using the last sources of PyMoDAQ from branches `4.4.x` and `5.0.x_dev` . (But it sometimes fail to not default to the last version available on `pip`) but provides reports in `.zip` artifact files.