### PR TITLE
Serialize thread command

### DIFF
--- a/src/pymodaq_utils/serialize/factory.py
+++ b/src/pymodaq_utils/serialize/factory.py
@@ -149,7 +149,7 @@ class SerializableFactory:
         else:
             raise NotImplementedError(f"There is no known method to serialize '{obj_type}'")
 
-    def get_apply_serializer(self, obj: Any, append_length=False) -> bytes:
+    def get_apply_serializer(self, obj: SERIALIZABLE, append_length=False) -> bytes:
         """
 
         Parameters

--- a/src/pymodaq_utils/serialize/factory.py
+++ b/src/pymodaq_utils/serialize/factory.py
@@ -62,7 +62,7 @@ class SerializableBase(metaclass=ABCMeta):
 
 
 # List of all objects serializable via the serializer
-SERIALIZABLE = Union[bytes, str, int, float, complex, list, NDArray, SerializableBase]
+SERIALIZABLE = Union[None, bytes, str, int, float, complex, list, NDArray, SerializableBase]
 
 Serializable = TypeVar("Serializable", bound=SERIALIZABLE)
 _SerializableClass = TypeVar("_SerializableClass", bound=SerializableBase)

--- a/src/pymodaq_utils/serialize/serializer.py
+++ b/src/pymodaq_utils/serialize/serializer.py
@@ -17,6 +17,16 @@ from ..serialize.factory import SerializableFactory, SERIALIZABLE, SerializableB
 ser_factory = SerializableFactory()
 
 
+class NoneSerializeDesieralize(SerializableBase):
+    @staticmethod
+    def serialize(obj: None) -> bytes:  # type: ignore[override]
+        return b""
+
+    @staticmethod
+    def deserialize(bytes_str: bytes) -> Tuple[None, bytes]:  # type: ignore[override]
+        return None, bytes_str
+
+
 class StringSerializeDeserialize(SerializableBase):
 
     @staticmethod
@@ -245,6 +255,9 @@ class ListSerializeDeserialize(SerializableBase):
         return list_obj, remaining_bytes
 
 
+ser_factory.register_from_type(
+    type(None), NoneSerializeDesieralize.serialize, NoneSerializeDesieralize.deserialize
+)
 ser_factory.register_from_type(bytes,
                                        BytesSerializeDeserialize.serialize,
                                        BytesSerializeDeserialize.deserialize)
@@ -268,6 +281,7 @@ ser_factory.register_from_type(list,
 
 class SerializableTypes(Enum):
     """Type names of serializable types"""
+    NONE = "NoneType"
     BOOL = "bool"
     BYTES = "bytes"
     STRING = "string"

--- a/src/pymodaq_utils/serialize/serializer.py
+++ b/src/pymodaq_utils/serialize/serializer.py
@@ -235,7 +235,7 @@ class ListSerializeDeserialize(SerializableBase):
         return bytes_string
 
     @staticmethod
-    def deserialize(bytes_str: bytes) -> Tuple[List[Any], bytes]:
+    def deserialize(bytes_str: bytes) -> Tuple[List[SERIALIZABLE], bytes]:
         """Convert bytes into a list of objects
 
         Convert the first bytes into a list reading first information about the list elt types, length ...
@@ -281,7 +281,7 @@ ser_factory.register_from_type(list,
 
 class SerializableTypes(Enum):
     """Type names of serializable types"""
-    NONE = "NoneType"
+    NONE = "NoneType"  # just in case it is needed
     BOOL = "bool"
     BYTES = "bytes"
     STRING = "string"

--- a/src/pymodaq_utils/utils.py
+++ b/src/pymodaq_utils/utils.py
@@ -10,7 +10,7 @@ import time
 from packaging import version as version_mod
 from pathlib import Path
 import traceback
-from typing import Any, List, Optional
+from typing import Any, cast, List, Optional, Tuple
 from typing import Iterable as IterableType
 from collections.abc import Iterable
 
@@ -19,6 +19,7 @@ import numpy as np
 from pymodaq_utils import logger as logger_module
 from pymodaq_utils.config import Config
 from pymodaq_utils.warnings import deprecation_msg
+from pymodaq_utils.serialize.factory import SerializableFactory, SerializableBase
 
 from importlib import metadata
 PackageNotFoundError = metadata.PackageNotFoundError  # for use elsewhere
@@ -170,8 +171,8 @@ def getLineInfo():
         res += t
     return res
 
-
-class ThreadCommand:
+@SerializableFactory.register_decorator()
+class ThreadCommand(SerializableBase):
     """Generic object to pass info (command) and data (attribute) between thread or objects using signals
 
     Parameters
@@ -217,6 +218,26 @@ class ThreadCommand:
             and self.args == other.args
             and self.kwargs == other.kwargs
         )
+
+    @staticmethod
+    def serialize(obj: "ThreadCommand") -> bytes:  # type: ignore[override]
+        serialize_factory = SerializableFactory()
+        byte_string = b""
+        byte_string += serialize_factory.get_apply_serializer(obj.command)
+        byte_string += serialize_factory.get_apply_serializer(obj.attribute)
+        return byte_string
+
+    @staticmethod
+    def deserialize(bytes_str: bytes) -> Tuple["ThreadCommand", bytes]:
+        serialize_factory = SerializableFactory()
+        command, remaining = cast(
+            Tuple[str, bytes],
+            serialize_factory.get_apply_deserializer(bytes_str=bytes_str, only_object=False),
+        )
+        attribute, remaining = cast(
+            Tuple[Any, bytes], serialize_factory.get_apply_deserializer(remaining, False)
+        )
+        return ThreadCommand(command, attribute), remaining
 
     def __repr__(self):
         return f'Threadcommand: {self.command} with attribute {self.attribute}'

--- a/tests/serialize/serializer_test.py
+++ b/tests/serialize/serializer_test.py
@@ -6,7 +6,9 @@ from pymodaq_utils.serialize.serializer import (StringSerializeDeserialize as SS
                                                 BytesSerializeDeserialize as BSD,
                                                 ScalarSerializeDeserialize as ScSD,
                                                 NdArraySerializeDeserialize as NdSD,
-                                                ListSerializeDeserialize as LSD,)
+                                                ListSerializeDeserialize as LSD,
+                                                NoneSerializeDesieralize as NSD,
+                                                )
 
 ser_factory = SerializableFactory()
 
@@ -24,6 +26,20 @@ DATA2D = np.arange(0, 5*6).reshape((5, 6))
 DATAND = np.arange(0, 5 * 6 * 3).reshape((5, 6, 3))
 Nn0 = 10
 Nn1 = 5
+
+
+def test_none_serialization():
+    obj_type = "NoneType"
+
+    assert NSD.serialize(None) == b""
+    assert (
+        ser_factory.get_serializer(type(None))(None)
+        == b"\x00\x00\x00" + chr(len(obj_type)).encode() + obj_type.encode()
+    )
+    assert ser_factory.get_serializer(type(None))(None) == ser_factory.get_apply_serializer(None)
+    assert NSD.deserialize(NSD.serialize(None)) == (None, b"")
+    assert ser_factory.get_apply_deserializer(ser_factory.get_apply_serializer(None)) is None
+
 
 
 def test_string_serialization():

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -7,6 +7,8 @@ import re
 from pathlib import Path
 import datetime
 
+from pymodaq_utils.serialize.factory import SerializableFactory
+
 from pymodaq_utils import utils
 
 
@@ -91,6 +93,35 @@ def test_ThreadCommand():
 def test_ThreadCommand_eq(other, expected):
     base = utils.ThreadCommand('test', [1, 2])
     assert (base == other) is expected
+
+
+class Test_ThreadCommand_Serialization:
+    test_pairs = (
+        (
+            utils.ThreadCommand("test", ["attr"]),
+            (
+                b"\x00\x00\x00\rThreadCommand\x00\x00\x00\x03str\x00\x00\x00\x04test"
+                b"\x00\x00\x00\x04list\x00\x00\x00\x01\x00\x00\x00\x03str\x00\x00\x00\x04attr"
+            ),
+        ),
+        (
+            utils.ThreadCommand("none"),
+            b"\x00\x00\x00\rThreadCommand\x00\x00\x00\x03str\x00\x00\x00\x04none\x00\x00\x00\x08NoneType",
+        ),
+    )
+    ids = ("with int", "with None attribute")
+
+    @pytest.mark.parametrize("test_pair", test_pairs, ids=ids)
+    def test_serialization(self, test_pair):
+        expected_tc, expected_bytes = test_pair
+        serialized = SerializableFactory().get_apply_serializer(expected_tc)
+        assert serialized == expected_bytes, serialized
+
+    @pytest.mark.parametrize("test_pair", test_pairs, ids=ids)
+    def test_deserialization(self, test_pair):
+        expected_tc, expected_bytes = test_pair
+        deser = SerializableFactory().get_apply_deserializer(expected_bytes)
+        assert deser == expected_tc
 
 
 def test_recursive_find_files_extension():


### PR DESCRIPTION
proper implementation of ThreadCommand serialization instead of the self written part in https://github.com/PyMoDAQ/PyMoDAQ/pull/405

This allows sending ThreadCommands via LECO, so should make status changes easier to transmit.

I'm not sure, whether I adjusted the `SerializableTypes` correctly.